### PR TITLE
Ignore contributions to package-lock.json

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 REACT_APP_API_URL = 'https://kasula-v7-5q5vehm3ja-ew.a.run.app'
+
+# 'http://127.0.0.1:8000'
+# 'https://kasula-v7-5q5vehm3ja-ew.a.run.app'

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+frontend/package-lock.json -diff

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env.local


### PR DESCRIPTION
The contributions by number of lines is destroyed by the package-lock.json file, because it is so large. This file should not be added to .gitignore because it is important for the installation of the packages, and even if we would like to add it to .gitignore, to delete the already changed lines we would have to override the entire history which is kind of ugly. But I would like not to count the line changes in this file towards the contribution graph.

I found out that by creating a .gitattributes and adding this file with -diff precisely does this.

This works in local stats but I need to push the changes to develop to see if the statistics are indeed fixed in GitHub.

Goodbye  49,224 ++ lines changed 👋 