### PR TITLE
Filter, Sort and Search Recipes + User Feed concurrent display of recipes

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-REACT_APP_API_URL = 'http://127.0.0.1:8000'
+REACT_APP_API_URL = 'https://kasula-develop-5q5vehm3ja-ew.a.run.app'
 
 # LA VARIABLE ESTÀ PENSADA PERQUÈ NO PORTI BARRA AL FINAL
 

--- a/src/assets/jsonData/sort_options.json
+++ b/src/assets/jsonData/sort_options.json
@@ -1,0 +1,28 @@
+{"fields": [{
+    "name": "none",
+    "displayName": "---"
+}, {
+    "name": "name",
+    "displayName": "Title"
+}, {
+    "name": "average_rating",
+    "displayName": "Rating"
+}, {
+    "name": "cooking_time",
+    "displayName": "Cooking Time"
+}, {
+    "name": "difficulty",
+    "displayName": "Difficulty"
+}, {
+    "name": "energy",
+    "displayName": "Energy"
+}, {
+    "name": "username",
+    "displayName": "Recipe Author"
+}, {
+    "name": "creation_date",
+    "displayName": "Creation Date"
+}, {
+    "name": "updated_at",
+    "displayName": "Last Modified"
+}]}

--- a/src/components/KasulaNavbar.jsx
+++ b/src/components/KasulaNavbar.jsx
@@ -135,6 +135,13 @@ function KasulaNavbar() {
                     <Dropdown.Menu className="dropdown-menu-end">
                       <Dropdown.Item
                         eventKey={1}
+                        href={`/UserProfile/${user._id}`}
+                      >
+                        Profile
+                      </Dropdown.Item>
+                      <Dropdown.Divider />
+                      <Dropdown.Item
+                        eventKey={2}
                         onClick={() => {
                           handleOpenModal();
                         }}

--- a/src/components/RecipeBrowser.jsx
+++ b/src/components/RecipeBrowser.jsx
@@ -118,8 +118,7 @@ function RecipeBrowser({ onSearch }) {
               ([key, value]) =>
                 value !== defaultFilters[key] ||
                 (key === "sortAscending" &&
-                  JSON.stringify(filtersOffCanvas.values) !==
-                    JSON.stringify(defaultFilters))
+                  filtersOffCanvas.values.sortBy !== "none")
             )
             .map(([key, value]) => (
               <Badge pill bg="secondary">

--- a/src/components/RecipeBrowser.jsx
+++ b/src/components/RecipeBrowser.jsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import {
+  Container,
+  Stack,
+  InputGroup,
+  Form,
+  Offcanvas,
+  Badge,
+} from "react-bootstrap";
+import { Funnel, FunnelFill, X, SortUp, SortDown } from "react-bootstrap-icons";
+
+import RecipeFilters from "./RecipeFilters";
+import "../css/common.css";
+
+function RecipeBrowser({ onSearch }) {
+  const defaultFilters = {
+    sortBy: "none",
+    sortAscending: false,
+    maxDifficulty: 5,
+    maxTime: 180,
+    minRating: 0,
+    maxCalories: 5000,
+  };
+
+  const [recipeName, setRecipeName] = useState("");
+  const [filtersOffCanvas, setFiltersOffCanvas] = useState({
+    title: "Filters",
+    show: false,
+    values: JSON.parse(
+      localStorage.getItem("filters") || {
+        sortBy: "none",
+        sortAscending: false,
+        maxDifficulty: 5,
+        maxTime: 180,
+        minRating: 0,
+        maxCalories: 5000,
+      }
+    ),
+  });
+
+  const handleCloseOffcanvas = (
+    setOffCanvasState,
+    offCanvasState,
+    applyFilters,
+    filterValues
+  ) => {
+    setOffCanvasState({
+      ...offCanvasState,
+      show: false,
+      values: filterValues || offCanvasState.values,
+    });
+    if (applyFilters) {
+      onSearch(filterValues || offCanvasState.values, recipeName);
+    }
+  };
+
+  return (
+    <Container>
+      <Container className="d-flex">
+        <span
+          className="fs-3 ms-auto me-3 colorless-span-button position"
+          role="button"
+          onClick={() => {
+            setFiltersOffCanvas({ ...filtersOffCanvas, show: true });
+          }}
+        >
+          <FunnelFill />
+        </span>
+        <InputGroup id="search-bar-container" className="w-25">
+          <Form.Control
+            className="d-flex shadow-none"
+            id="search-bar"
+            type="text"
+            placeholder="Search..."
+            value={recipeName}
+            onChange={(e) => {
+              setRecipeName(e.target.value);
+              onSearch(filtersOffCanvas.values, e.target.value);
+            }}
+          />
+          <InputGroup.Text className="fs-4" id="search-bar-clear">
+            {recipeName.length > 0 && (
+              <X
+                className="colorless-span-button"
+                role="button"
+                onClick={() => {
+                  setRecipeName("");
+                  onSearch(filtersOffCanvas.values, "");
+                }}
+              />
+            )}
+          </InputGroup.Text>
+        </InputGroup>
+      </Container>
+      <Container className="d-flex mt-4">
+        {JSON.stringify(filtersOffCanvas.values) !==
+          JSON.stringify(defaultFilters) && (
+          <div
+            className="d-flex colorless-span-button me-4"
+            role="button"
+            onClick={() => {
+              setFiltersOffCanvas({
+                ...filtersOffCanvas,
+                values: defaultFilters,
+              });
+              localStorage.setItem("filters", JSON.stringify(defaultFilters));
+              onSearch(defaultFilters, recipeName);
+            }}
+          >
+            <X className="fs-5 mt-1" />
+            <span className="mx-2">Clear filters</span>
+            <Funnel className="fs-5 mt-1" />
+          </div>
+        )}
+        <Stack direction="horizontal" gap={2}>
+          {Object.entries(filtersOffCanvas.values)
+            .filter(
+              ([key, value]) =>
+                value !== defaultFilters[key] ||
+                (key === "sortAscending" &&
+                  JSON.stringify(filtersOffCanvas.values) !==
+                    JSON.stringify(defaultFilters))
+            )
+            .map(([key, value]) => (
+              <Badge pill bg="secondary">
+                {key}:{" "}
+                {value === true
+                  ? "Yes"
+                  : value === false
+                  ? "No"
+                  : value.toString()}
+                {key === "sortAscending" ? (
+                  <div
+                    className="ms-1 d-inline-block"
+                    role="button"
+                    onClick={() => {
+                      const newValues = { ...filtersOffCanvas.values };
+                      newValues[key] = !newValues[key];
+                      setFiltersOffCanvas({
+                        ...filtersOffCanvas,
+                        values: newValues,
+                      });
+                      localStorage.setItem(
+                        "filters",
+                        JSON.stringify(newValues)
+                      );
+                      onSearch(newValues, recipeName);
+                    }}
+                  >
+                    {value ? (
+                      <SortUp />
+                    ) : (
+                      <SortDown className="ms-1" role="button" />
+                    )}
+                  </div>
+                ) : (
+                  <X
+                    className="ms-1"
+                    role="button"
+                    onClick={() => {
+                      const newValues = { ...filtersOffCanvas.values };
+                      newValues[key] = defaultFilters[key];
+                      setFiltersOffCanvas({
+                        ...filtersOffCanvas,
+                        values: newValues,
+                      });
+                      localStorage.setItem(
+                        "filters",
+                        JSON.stringify(newValues)
+                      );
+                      onSearch(newValues, recipeName);
+                    }}
+                  />
+                )}
+              </Badge>
+            ))}
+        </Stack>
+      </Container>
+      <Offcanvas
+        show={filtersOffCanvas.show}
+        onHide={() =>
+          handleCloseOffcanvas(setFiltersOffCanvas, filtersOffCanvas, false)
+        }
+      >
+        <Offcanvas.Header closeButton className="bg-normal">
+          <Offcanvas.Title className="fs-3 fw-semi-bold">
+            {filtersOffCanvas.title}
+          </Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body className="p-0">
+          <RecipeFilters
+            onClose={(filters) => {
+              localStorage.setItem("filters", JSON.stringify(filters));
+              handleCloseOffcanvas(
+                setFiltersOffCanvas,
+                filtersOffCanvas,
+                true,
+                filters
+              );
+            }}
+            inValues={filtersOffCanvas.values}
+          />
+        </Offcanvas.Body>
+      </Offcanvas>
+    </Container>
+  );
+}
+
+export default RecipeBrowser;

--- a/src/components/RecipeBrowser.jsx
+++ b/src/components/RecipeBrowser.jsx
@@ -45,16 +45,7 @@ function RecipeBrowser({ onSearch }) {
   const [filtersOffCanvas, setFiltersOffCanvas] = useState({
     title: "Filters",
     show: false,
-    values: JSON.parse(
-      localStorage.getItem("filters") || {
-        sortBy: "none",
-        sortAscending: false,
-        maxDifficulty: 5,
-        maxTime: 180,
-        minRating: 0,
-        maxCalories: 5000,
-      }
-    ),
+    values: JSON.parse(localStorage.getItem("filters")) || defaultFilters,
   });
 
   const handleCloseOffcanvas = (

--- a/src/components/RecipeBrowser.jsx
+++ b/src/components/RecipeBrowser.jsx
@@ -10,9 +10,28 @@ import {
 import { Funnel, FunnelFill, X, SortUp, SortDown } from "react-bootstrap-icons";
 
 import RecipeFilters from "./RecipeFilters";
+import sort_options from "../assets/jsonData/sort_options.json";
 import "../css/common.css";
 
 function RecipeBrowser({ onSearch }) {
+  const keyParsing = {
+    sortBy: "Sort by:",
+    sortAscending: "",
+    maxDifficulty: "Difficulty:",
+    maxTime: "Time:",
+    minRating: "Rating:",
+    maxCalories: "Calories",
+  };
+
+  const valueParsing = {
+    sortBy: "",
+    sortAscending: "",
+    maxDifficulty: " stars or less",
+    maxTime: " min or less",
+    minRating: " stars or more",
+    maxCalories: " cal or less",
+  };
+
   const defaultFilters = {
     sortBy: "none",
     sortAscending: false,
@@ -122,12 +141,16 @@ function RecipeBrowser({ onSearch }) {
             )
             .map(([key, value]) => (
               <Badge pill bg="secondary">
-                {key}:{" "}
-                {value === true
-                  ? "Yes"
+                {keyParsing[key]}{" "}
+                {key === "sortBy"
+                  ? sort_options.fields.filter(
+                      (option) => option.name === value
+                    )[0].displayName
+                  : value === true
+                  ? "Ascending"
                   : value === false
-                  ? "No"
-                  : value.toString()}
+                  ? "Descending"
+                  : value.toString().concat(valueParsing[key])}
                 {key === "sortAscending" ? (
                   <div
                     className="ms-1 d-inline-block"

--- a/src/components/RecipeFilters.jsx
+++ b/src/components/RecipeFilters.jsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Container, Button, Form } from "react-bootstrap";
+import { SortUp, SortDown, X, Funnel } from "react-bootstrap-icons";
+import StarSelector from "./StarSelector";
+import sortOptions from "../assets/jsonData/sort_options.json";
+
+function RecipeFilters({ onClose, inValues }) {
+  const defaultFilters = {
+    sortBy: "none",
+    sortAscending: false,
+    maxDifficulty: 5,
+    maxTime: 180,
+    minRating: 0,
+    maxCalories: 5000,
+  };
+
+  const [filters, setFilters] = useState(inValues || defaultFilters);
+
+  return (
+    <Container className="bg-lightest min-vh-100 p-4">
+      {JSON.stringify(filters) !== JSON.stringify(defaultFilters) && (
+        <div
+          className="d-flex colorless-span-button mb-4"
+          role="button"
+          onClick={() => setFilters(defaultFilters)}
+        >
+          <X className="fs-5 mt-1" />
+          <span className="mx-2">Clear filters</span>
+          <Funnel className="fs-5 mt-1" />
+        </div>
+      )}
+      <Form>
+        <Form.Group>
+          <Form.Label>Sort By</Form.Label>
+          <div className="d-flex">
+            <Form.Select className="me-3" defaultValue={filters.sortBy}>
+              {sortOptions.fields.map((option) => (
+                <option
+                  key={option.id}
+                  value={option.name}
+                  onClick={() => {
+                    setFilters({
+                      ...filters,
+                      sortBy: option.name,
+                    });
+                  }}
+                >
+                  {option.displayName}
+                </option>
+              ))}
+            </Form.Select>
+            <span
+              className="fs-4 colorless-span-button"
+              role="button"
+              onClick={() => {
+                setFilters({
+                  ...filters,
+                  sortAscending: !filters.sortAscending,
+                });
+              }}
+            >
+              {filters.sortAscending ? <SortUp /> : <SortDown />}
+            </span>
+          </div>
+        </Form.Group>
+        <Form.Group className="mt-4">
+          <Form.Label className="mb-0">Difficulty</Form.Label>
+          <div>
+            <StarSelector
+              maxValue={5}
+              value={filters.maxDifficulty}
+              starSize={2}
+              type={"difficulty"}
+              onSelect={(value) =>
+                setFilters({ ...filters, maxDifficulty: value })
+              }
+            />
+          </div>
+        </Form.Group>
+        <Form.Group className="mt-4">
+          <Form.Label className="mb-0">Rating</Form.Label>
+          <div>
+            <StarSelector
+              maxValue={5}
+              value={filters.minRating}
+              starSize={2}
+              type={"rating"}
+              onSelect={(value) => setFilters({ ...filters, minRating: value })}
+            />
+          </div>
+        </Form.Group>
+        <Form.Group className="mt-4">
+          <Form.Label className="mb-0">Time</Form.Label>
+          <div className="position-relative">
+            <Form.Range
+              min={0}
+              max={180}
+              value={filters.maxTime}
+              title={filters.maxTime + " min"}
+              onChange={(e) =>
+                setFilters({ ...filters, maxTime: e.target.value })
+              }
+            />
+            <div className="position-absolute bottom-100 start-50 translate-middle-x">
+              {filters.maxTime} min
+            </div>
+          </div>
+        </Form.Group>
+        <div className="d-flex justify-content-between">
+          <span>0 min</span>
+          <span>180 min</span>
+        </div>
+        <Form.Group className="mt-4">
+          <Form.Label className="mb-0">Calories</Form.Label>
+          <div className="position-relative">
+            <Form.Range
+              min={0}
+              max={5000}
+              value={filters.maxCalories}
+              onChange={(e) =>
+                setFilters({ ...filters, maxCalories: e.target.value })
+              }
+            />
+            <div className="position-absolute bottom-100 start-50 translate-middle-x">
+              {filters.maxCalories} cal
+            </div>
+          </div>
+        </Form.Group>
+        <div className="d-flex justify-content-between">
+          <span>0 cal</span>
+          <span>5000 cal</span>
+        </div>
+        <div className="d-flex justify-content-center">
+          <Button
+            className="positive-button border-0 mt-4"
+            id="mainButton"
+            onClick={() => onClose(filters)}
+          >
+            Apply
+          </Button>
+        </div>
+      </Form>
+    </Container>
+  );
+}
+
+export default RecipeFilters;

--- a/src/components/RecipeList.jsx
+++ b/src/components/RecipeList.jsx
@@ -1,5 +1,6 @@
 //React
 import { CSSTransition } from "react-transition-group";
+import { useRef, useEffect } from "react";
 
 //Bootstrap
 import { Link } from "react-router-dom";
@@ -11,21 +12,39 @@ import RecipeCard from "./RecipeCard";
 
 //CSS
 import "../css/Transitions.css";
+import { wait } from "@testing-library/user-event/dist/utils";
 
-function recipeList({ recipes, canDelete, onDeleteRecipe, id, token }) {
+function RecipeList({ recipes, canDelete, onDeleteRecipe, onRequestLoadMore, id, token, finished }) {
+  const myRef = useRef();
+  useEffect(() => {
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && !finished) {
+        onRequestLoadMore();
+        observer.unobserve(entries[0].target);
+      }
+    });
+    if (myRef.current) {
+      observer.observe(myRef.current);
+    }
+    return () => {
+      if (myRef.current) {
+        observer.unobserve(myRef.current);
+      }
+    };
+  }, [myRef, recipes]);
   return (
     <Container className="pb-5 pt-3">
       <Row>
         {recipes && recipes.length > 0 ? (
-          recipes.map((recipe) => (
-            <Col sm={12} md={6} xl={4}>
+          recipes.map((recipe, index) => (
+            <Col key={recipe._id} sm={12} md={6} xl={4}>
               <CSSTransition
                 in={true}
                 timeout={500}
                 classNames="slideUp"
                 appear
               >
-                <div className="position-relative transition-03s">
+                <div ref={(index === recipes.length - 6 ) ? myRef : null} className="position-relative transition-03s">
                   <Link
                     key={recipe._id}
                     to={`/RecipeDetail/${recipe._id}`}
@@ -67,7 +86,7 @@ function recipeList({ recipes, canDelete, onDeleteRecipe, id, token }) {
           ))
         ) : (
           <div className="alert alert-warning" role="alert">
-            There are currently no recipes
+            {canDelete ? "There are currently no recipes" : "There are no recipes matching the search or filters"}
           </div>
         )}
       </Row>
@@ -75,4 +94,4 @@ function recipeList({ recipes, canDelete, onDeleteRecipe, id, token }) {
   );
 }
 
-export default recipeList;
+export default RecipeList;

--- a/src/components/Root.js
+++ b/src/components/Root.js
@@ -21,6 +21,7 @@ import CollectionView from "./CollectionView";
 import "../css/Transitions.css";
 import "../css/Root.css";
 import "../css/common.css";
+import "../css/slider.css";
 
 function Root() {
   return (

--- a/src/components/StarSelector.jsx
+++ b/src/components/StarSelector.jsx
@@ -1,0 +1,39 @@
+import { useState } from "react";
+import { Star, StarFill } from "react-bootstrap-icons";
+
+function StarSelector({ onSelect, maxValue, value, starSize, type }) {
+  const [hoveredStar, setHoveredStar] = useState({
+    value: 0,
+    active: false,
+  });
+  let stars = [];
+  for (let i = 1; i <= maxValue; i++) {
+    const isActive = i <= value;
+    const isHovered = i <= hoveredStar.value && hoveredStar.active;
+    const aboveHovered = i > hoveredStar.value && hoveredStar.active;
+    stars.push(
+      <span
+        key={i}
+        className={""
+          .concat(type)
+          .concat("-star ")
+          .concat(isActive ? "active" : "inactive")
+          .concat(isHovered ? ((isActive && i === hoveredStar.value && i === value) ? " above-hovered" : " hovered") : "")
+          .concat(aboveHovered ? " above-hovered" : "")
+          .concat(" ms-2 fs-")
+          .concat(7 - starSize)}
+        role="button"
+        onClick={() => {
+          onSelect((isActive && i === value ? i - 1 : i));
+        }}
+        onMouseEnter={() => setHoveredStar({ value: i, active: true })}
+        onMouseLeave={() => setHoveredStar({ value: 0, active: false })}
+      >
+        {isActive || isHovered ? <StarFill /> : <Star />}
+      </span>
+    );
+  }
+  return stars;
+}
+
+export default StarSelector;

--- a/src/components/UserFeed.jsx
+++ b/src/components/UserFeed.jsx
@@ -1,25 +1,59 @@
 //React
 import React, { useState, useEffect } from "react";
+import { useAuth } from "./AuthContext";
 import RecipeList from "./RecipeList";
+import RecipeBrowser from "./RecipeBrowser";
 
 //Bootstrap
 import { Container, Spinner } from "react-bootstrap";
 
 function UserFeed() {
+  const { isLogged } = useAuth();
+  const numRecipes = isLogged() ? 24 : 9;
+  const loggedOutFilters = {
+    sortBy: "average_rating",
+    sortAscending: false,
+  };
+  const [page, setPage] = useState(0);
+  const [filters, setFilters] = useState(isLogged() ? (JSON.parse(localStorage.getItem("filters"))) : loggedOutFilters);
+  const [recipeName, setRecipeName] = useState(null);
   const [recipes, setRecipes] = useState([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [finished, setFinished] = useState(isLogged() ? false : true);
 
   useEffect(() => {
-    getRecipes();
+    getRecipes(filters, recipeName, page, numRecipes, true);
   }, []);
 
-  const getRecipes = () => {
+  useEffect(() => {
+    if (!isLogged()) {
+      setFinished(true);
+      setPage(0);
+      setFilters(loggedOutFilters);
+      setRecipeName(null);
+      getRecipes(loggedOutFilters, null, 0, 9, true);
+    }
+  }, [isLogged]);
+
+  const getRecipes = ( filters, recipeName, page, numRecipes, reset ) => {
+    if (loading) return;
     setLoading(true);
-    fetch(process.env.REACT_APP_API_URL + "/recipe/")
-      .then((response) => response.json())
+    fetch(buildRequestUrl(filters, recipeName, page, numRecipes))
+      .then((response) => {
+        if (!response.ok) {
+          if (response.status === 400) {
+            setPage(page - 1);
+            setFinished(true);
+          }
+        }
+        return response.json();
+      })
       .then((data) => {
-        console.log(data)
-        setRecipes(data);
+        if (reset) {
+          setRecipes(data);
+        } else {
+          setRecipes(recipes.concat(data));
+        }
         setLoading(false);
       })
       .catch((error) => { 
@@ -28,14 +62,54 @@ function UserFeed() {
       });
   }
 
+  const buildRequestUrl = (filters, recipeName, page, numRecipes) => {
+    let url = process.env.REACT_APP_API_URL + "/recipe/" + (filters || recipeName || page || numRecipes ? "magic?" : "");
+    if (filters) {
+      url += (filters.sortBy === 'none') ? '' : `sort_by=${filters.sortBy}&`;
+      url += (filters.sortBy === 'none') ? '' : `order=${filters.sortAscending}&`;
+      url += filters.maxDifficulty ? `max_difficulty=${filters.maxDifficulty}&` : '';
+      url += filters.maxTime ? `max_cooking_time=${filters.maxTime}&` : '';
+      url += filters.minRating ? `min_rating=${filters.minRating}&` : '';
+      url += filters.maxCalories ? `max_energy=${filters.maxCalories}&` : '';
+    }
+    if (recipeName) {
+      url += `search=${recipeName}&`;
+    }
+    if (page !== null && numRecipes !== null) {
+      url += `start=${page * numRecipes}&`;
+      url += `size=${numRecipes}`;
+    }
+    console.log(url);
+    return url;
+  }
+
   return (
-    loading ? (
+    <Container className="py-5">
+      {isLogged() && (
+        <RecipeBrowser onSearch={(filters, recipeName) => {
+        setPage(0);
+        setFinished(false);
+        setFilters(filters);
+        setRecipeName(recipeName);
+        getRecipes(filters, recipeName, 0, numRecipes, true);
+        }}/>
+      )}
+      {loading && recipes.length === 0 ? (
       <Container className="d-flex justify-content-center align-items-center min-vh-100">
         <Spinner animation="border" variant="secondary"/>
       </Container>
-    ) : ( 
-      <RecipeList recipes={recipes} /> 
-    )
+      ) : ( 
+        <RecipeList onRequestLoadMore={() => {
+          setPage(page + 1);
+          getRecipes(filters, recipeName, page + 1, numRecipes, false);
+        }} recipes={recipes} finished={finished}/> 
+      )}
+      {!isLogged() && (
+        <div className="alert alert-warning b-4" role="alert">
+            This is as far as you can go. Please, <a href="/login">login</a> or <a href="/signup">register</a> to see more recipes.
+        </div>
+      )}
+    </Container>
   );
 
 }

--- a/src/css/PostRecipe.css
+++ b/src/css/PostRecipe.css
@@ -3,7 +3,15 @@
 }
 
 .difficulty-star.active:hover {
-  color: rgb(151, 114, 1);
+  color: rgb(151, 91, 1);
+}
+
+.difficulty-star.active.hovered {
+  color: rgb(151, 91, 1);
+}
+
+.difficulty-star.active.above-hovered {
+  color: #7c7c7c;
 }
 
 .difficulty-star.inactive {
@@ -12,6 +20,10 @@
 
 .difficulty-star.inactive:hover {
   color: #7c7c7c;
+}
+
+.difficulty-star.inactive.hovered {
+  color: rgb(151, 91, 1);
 }
 
 .add-ingredient-button.active {

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -120,3 +120,51 @@
     border-top-right-radius: 25px;
     border-bottom-right-radius: 25px;
 }
+
+#search-bar {
+    border-right: none;
+    transition: none;
+}
+
+#search-bar-clear {
+    background-color: white;
+    border-left: none;
+    cursor: text;
+    transition: none;
+}
+
+#search-bar-container:focus-within #search-bar {
+    border-color: #80bdff;
+}
+
+#search-bar-container:focus-within #search-bar-clear {
+    border-color: #80bdff;
+}
+
+.rating-star.active {
+    color: #e0b700;
+}
+
+.rating-star.active:hover {
+    color: rgb(151, 124, 43);
+}
+
+.rating-star.active.hovered {
+    color: rgb(151, 124, 43);
+}
+
+.rating-star.active.above-hovered {
+    color: #7c7c7c;
+}
+
+.rating-star.inactive {
+    color: #a7a7a7;
+}
+
+.rating-star.inactive:hover {
+    color: #7c7c7c;
+}
+
+.rating-star.inactive.hovered {
+    color: rgb(151, 124, 43);
+}

--- a/src/css/slider.css
+++ b/src/css/slider.css
@@ -1,0 +1,37 @@
+input[type=range]::-webkit-slider-runnable-track {
+    background: #ddd;
+}
+
+input[type=range]::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    background: rgb(255, 74, 42);
+}
+
+input[type=range]:focus {
+    outline: none;
+}
+
+input[type=range]:focus::-webkit-slider-runnable-track {
+    background: #ffafaf;
+}
+
+input[type=range]::-moz-range-track {
+    background: #ffafaf;
+}
+
+input[type=range]::-moz-range-thumb {
+    background: rgb(255, 74, 42);
+}
+
+input[type=range]:focus::-moz-range-thumb {
+    background: rgb(155, 26, 4);
+}
+
+/*hide the outline behind the border*/
+input[type=range]:-moz-focusring {
+    outline: none;
+}
+
+input[type=range]:focus::-moz-range-track {
+    background: #ffc0c0;
+}


### PR DESCRIPTION
When the user is not logged in, they will see only 9 recipes:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/544e9ef0-a808-43fa-a254-70ef4b89d3f8)

If they scroll to the bottom, they will see this message:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/4dddf253-6f4b-4f30-9463-52b8c8a8f1c6)

And each button redirects to the corresponding page. When the user logs in now, they see this:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/4fb8a7e9-50ca-4c60-9f35-caef118dcf69)

They can now click their profile image to go to their profile or, alternatively, can use the contextual dropdown menu when clicking on their username:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/633d6078-5449-4050-bc66-054c23c8a2e5)

Typing in the search bar will dynamically filter recipes by name, following the backend model, where not only recipe titles are factored in, but also usernames of the creators and recipe ingredients:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/f52c337f-3fa5-4d06-b9ec-1f296f47ae54)

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/ed06294e-0035-4373-b4bf-3e8f0d911385)

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/1468f53e-af91-4672-af32-a57a798db168)

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/76d02e61-3c44-4cb8-821e-1c5c40a30f42)

clicking the filter funnel will prompt an off canvas where the user can select different filters:

![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/cbda209d-667a-4e6a-9a16-0c2cee546966)

When apply is clicked the filters are saved in the local storage and applied to the search, using the magic endpoint in the backend. Then, these filters appear as pills before the recipes list:
![image](https://github.com/UB-ES-2023-A2/kasula-frontend/assets/72074467/5e6775b5-a6bd-4f1c-9778-25f7b8dc92e8)

The condition for these pills to appear or not is based on the default filters, if any match the default corresponding filter, it will not be displayed. This is an exception with the ascending/descending filter, which is tied to the sort_by filter, and thus its visibility will depend on it. You can change the ascending/descending order or outright remove a filter using the icon on the left. This will update the recipes list and the local storage.

The clear filters button is used to restore to default values. 

Last but not least, now recipes are retrieved dynamically, when reaching the end of the list, more list will be loaded, except if there are no more recipes left to retrieve. 

If the user logs out, the recipes list changes to the previously mentioned one, where only 9 recipes sorted by rating appear.